### PR TITLE
IO-724 deleteDirectory exception javadoc update

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1180,7 +1180,7 @@ public class FileUtils {
      *
      * @param directory directory to delete
      * @throws IOException              in case deletion is unsuccessful
-     * @throws IllegalArgumentException if {@code directory} does not exist or is not a directory
+     * @throws NullPointerException - if {@code directory} is null
      */
     public static void deleteDirectory(final File directory) throws IOException {
         Objects.requireNonNull(directory, "directory");


### PR DESCRIPTION
FileUtils.deleteDirectory javadoc is inaccurate for nonexistent directory
